### PR TITLE
2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Common CMake settings
-SET(PACKAGE_VERSION 1.1.1)
+SET(PACKAGE_VERSION 2.0.0)
 project(LogHelper LANGUAGES C CXX VERSION ${PACKAGE_VERSION} DESCRIPTION "Log Helper for radiation experiments")
 
 ########################################################################################################################
@@ -54,20 +54,19 @@ add_library(
 ########################################################################################################################
 # Set the logging approach
 # UPDATE IF THERE IS CHANGES on common.hpp
-#    enum class LoggingType{
-#        LOCAL_ONLY = 0,
-#        UDP_ONLY,
-#        LOCAL_AND_UDP
-#    } ;
-if (NOT LOGGING_TYPE OR LOGGING_TYPE STREQUAL "LOCAL")
+# DEPRECATED: Setting at compile time logging type is now deprecated, LOGGING_TYPE will be set in the config file
+if (LOGGING_TYPE STREQUAL "LOCAL")
     message("-- Selecting LOCAL logging approach")
-    add_definitions(-DLOGGING_TYPE=0)
+    set(LOGGING_TYPE 0)
+    #    add_definitions(-DLOGGING_TYPE=0)
 elseif (LOGGING_TYPE STREQUAL "UDP")
     message("-- Selecting UDP logging approach")
-    add_definitions(-DLOGGING_TYPE=1)
-elseif (LOGGING_TYPE STREQUAL "LOCAL_AND_UDP")
+    #    add_definitions(-DLOGGING_TYPE=1)
+    set(LOGGING_TYPE 1)
+elseif (NOT LOGGING_TYPE OR LOGGING_TYPE STREQUAL "LOCAL_AND_UDP")
     message("-- Selecting LOCAL_AND_UPD logging approach")
-    add_definitions(-DLOGGING_TYPE=2)
+    #    add_definitions(-DLOGGING_TYPE=2)
+    set(LOGGING_TYPE 2)
 else ()
     message(FATAL_ERROR "INVALID LOGGING_TYPE CONFIGURATION, USE: LOCAL, UPD, LOCAL_AND_UDP")
 endif ()
@@ -98,18 +97,21 @@ install(FILES ${CMAKE_BINARY_DIR}/LogHelper.pc DESTINATION ${CMAKE_INSTALL_DATAR
 # Path to the radiation-benchmarks repository
 set(HOME_DIR $ENV{HOME})
 
-# Set radiation-benchmarks directory to keep compatibility with older setup
-if (NOT RAD_BENCHS_INSTALL_DIR)
-    set(RAD_BENCHS_INSTALL_DIR ${HOME_DIR}/radiation-benchmarks)
-endif ()
+# Deprecated: Removed support for the old setup
+## Set radiation-benchmarks directory to keep compatibility with older setup
+#if (NOT RAD_BENCHS_INSTALL_DIR)
+#    set(RAD_BENCHS_INSTALL_DIR ${HOME_DIR}/radiation-benchmarks)
+#endif ()
+# Deprecated: signal sending
 # Killall signal command to be sent to the SW watchdog
-if (NOT WATCHDOG_COMMANDS)
-    set(WATCHDOG_COMMANDS "none")
-endif ()
-# System tmp dir
-if (NOT TMP_DIR)
-    set(TMP_DIR /tmp)
-endif ()
+#if (NOT WATCHDOG_COMMANDS)
+#    set(WATCHDOG_COMMANDS "none")
+#endif ()
+## System tmp dir
+#if (NOT TMP_DIR)
+#    set(TMP_DIR /tmp)
+#endif ()
+
 # Path to file that will contains 1/0 that refers to ECC enabled or disabled respectively.
 if (NOT ECC_INFO_FILE_DIR)
     set(ECC_INFO_FILE_DIR /tmp/ecc-info-file.txt)

--- a/README.md
+++ b/README.md
@@ -65,33 +65,35 @@ To uninstall the library (LOG_DIR/radiation-benchmarks/ path is not deleted)
 sudo make uninstall
 ```
 
-Then to use you just have to build the benchmark with this library use -lLogHelper with -I<install_path>/include -L<
-install_path>/lib
-(if not installed in the system)
+## How to use the library
 
-```C
+
+Then to use you just have to build the benchmark with this library use -lLogHelper with -I<install_path>/include -L<
+install_path>/lib (if not installed in the system).
+Then include in your C/C++ code as follows:
+
+```C++
 // include the header in your C code
-#include
-"log_helper.h"
+#include "log_helper.h"
 ...
 // include the header in your C++ code
-#include
-"log_helper.hpp"
+#include "log_helper.hpp"
 ```
 
 ### Python Wrapper
 
-It is possible to use the Python 3.8 wrapper to use the library on Python apps. You have to set the path to the build
+It is possible to use the Python >=3.8 wrapper to use the library on Python apps. You have to set the path to the build
 folder, then just call the same name as:
 
 ```python
 import log_helper as lh
-
-lh.start_log_file("MyBenchmark", "Myheader")
 ...
 ```
 
-### How to use the library
+### Examples and docs
 
 Some dummy source codes in [examples/](https://github.com/radhelper/libLogHelper/tree/main/examples) directory contain
-the library's essential functions usage.
+the library's essential functions usage. 
+A description of the main libLogHelper functions can be found in 
+[the docs](https://github.com/radhelper/libLogHelper/tree/main/docs.md)
+

--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ You can set some library functionalities on CMake:
     - Default: ON
 - -DWITH_DEBUG=\<ON/OFF to disable debug printing information\>
     - Default: OFF
-- -DRAD_BENCHS_INSTALL_DIR=\<path to rad benchmarks\>
-    - Default: /home/carol/radiation-benchmarks
-- -DWATCHDOG_COMMANDS=\<signal command to be sent to the local software watchdog\>
-    - Example: -DWATCHDOG_COMMANDS="killall -q -USR1 watchdog1.py; killall -q -USR1 watchdog2.py;"
-    - Default: none
-- -DTMP_DIR=\<System tmp dir\>
-    - Default: /tmp
 - -DECC_INFO_FILE_DIR=\<Path to file that will contain 1/0 that refers to ECC
   enabled or disabled respectively\>
     - Default: /tmp/ecc-info-file.txt

--- a/cmake_install_scripts/radiation-benchmarks.conf.in
+++ b/cmake_install_scripts/radiation-benchmarks.conf.in
@@ -1,10 +1,8 @@
 [DEFAULT]
-installdir = @RAD_BENCHS_INSTALL_DIR@
 vardir = @LOG_DIR@/radiation-benchmarks
 logdir = @LOG_DIR@/radiation-benchmarks/log
-tmpdir = @TMP_DIR@
-signalcmd = @WATCHDOG_COMMANDS@
 eccinfofile = @ECC_INFO_FILE_DIR@
 serverip = @SERVER_IP@
 serverport = @SERVER_PORT@
+loggingtype = @LOGGING_TYPE@
 

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,94 @@
+# Main LibLogHelper functions
+
+The functions of libLogHelper are:
+
+- **start_log_file**: Generate the log file name, log info from user about the test to be executed
+  and reset log variables. The C++ can be used with the namespace log_helper.
+  For the python wrapper the functions have the same name and parameters.
+
+  ```C++
+  int start_log_file(const char *benchmark_name, const char *test_info);
+  ```
+
+- **set_max_errors_iter**: Set the max errors that can be logged for a single iteration.
+  If more than max errors is found, exit the program. Default is 500.
+
+  ```C++
+  unsigned long int set_max_errors_iter(unsigned long int max_errors);
+  ```
+
+- **set_max_infos_iter**: Set the max number of infos logged in a single iteration. 
+Default is 500.
+
+  ```C++
+  unsigned long int set_max_infos_iter(unsigned long int max_infos);
+  ```
+
+- **set_iter_interval_print**: Set the interval the program must log iteration details, 
+default is 1 (each iteration will be logged). 
+This is generally useful when using networking logging.
+
+  ```C++
+  int set_iter_interval_print(int interval);
+  ```
+
+- **disable_double_error_kill**: Disable the double error kill mechanism. 
+This will prevent the program from terminating if two errors occur sequentially. 
+  ```C++
+    void disable_double_error_kill();
+    ```
+
+- **end_log_file**: Log the string "#END" to the log file and reset global variables. 
+
+    ```C++
+    int end_log_file();
+    ```
+
+- **start_iteration**: Start timing the kernel execution, update the iteration number, 
+and log this information to the file.
+
+    ```C++
+    int start_iteration();
+    ```
+
+- **end_iteration**: Complete the kernel time measurement and log both the total execution 
+time and kernel time to the log file. 
+
+    ```C++
+    int end_iteration();
+    ```
+
+- **log_error_count**: Update the total error count and log both the total errors 
+and iteration i kernel-specific errors to the log file. 
+Be aware that if the total errors is higher than the value set_max_errors_iteration 
+the function will throw an exception. 
+
+    ```C++
+    int log_error_count(unsigned long int kernel_errors);
+    ```
+
+- **log_info_count**: Update the total info count and log both the total and 
+iteration-specific info count to the log file.
+
+    ```C++
+    int log_info_count(unsigned long int info_count);
+    ```
+
+- **log_error_detail**: Log the provided error detail string to the log file. 
+
+    ```C++
+    int log_error_detail(const char *error_detail);
+    ```
+
+- **log_info_detail**: Log the provided information detail string to the log file. 
+
+    ```C++
+    int log_info_detail(const char *info_detail);
+    ```
+
+- **get_log_file_name**: Store the name of the generated log file in the `log_file_name` variable and return a pointer
+  to it. 
+
+    ```C++
+    char *get_log_file_name(char *log_file_name);
+    ```

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -26,8 +26,8 @@ namespace log_helper {
         LOCAL_AND_UDP = 2
     } LoggingType;
 
-#ifndef LOGGING_TYPE
-#define LOGGING_TYPE LOCAL_ONLY
-#endif
+    // #ifndef LOGGING_TYPE
+    // #define LOGGING_TYPE LOCAL_ONLY
+    // #endif
 }
 #endif //LIB_LOGHELPER_COMMON_HPP

--- a/include/env_vars.h
+++ b/include/env_vars.h
@@ -13,8 +13,6 @@
 
 // directory that the logs will be saved locally
 #define LOG_DIR_KEY "logdir"
-// Command that log_helper lib will send to the watchdog
-#define SIGNAL_CMD_KEY "signalcmd"
 // Path to the configuration files that log helper will save
 #define VAR_DIR_KEY "vardir"
 // key to load ecc verification data
@@ -22,13 +20,14 @@
 // Config for UDP logging
 #define SERVER_IP_KEY "serverip"
 #define SERVER_PORT_KEY "serverport"
+// Define the logging type at the config file
+#define LOGGING_TYPE "loggingtype"
+// // Deprecated: Command that log_helper lib will send to the watchdog
+// #define SIGNAL_CMD_KEY "signalcmd"
 
 #ifndef CONFIG_FILE_PATH
 #error "CONFIG_FILE_PATH not set check you CMake configurations"
 #endif
 
-/** Deprecated: Timestamps are righter updated by UDP messages or signals to local watchdogs **/
-// Location of timestamp file for software watchdog
-//#define TIMESTAMP_FILE "timestamp.txt"
 
 #endif //LOGHELPER_ENV_VARS_H

--- a/include/file_writer.hpp
+++ b/include/file_writer.hpp
@@ -5,19 +5,14 @@
 #ifndef LOGHELPER_FILE_DESCRIPTOR_HPP
 #define LOGHELPER_FILE_DESCRIPTOR_HPP
 
-#include <fstream>
 #include <string>
-#include <iostream>
-#include <utility>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
 #include <netinet/in.h>
-#include "common.hpp"
 
 namespace log_helper {
     class FileBase {
     public:
+        virtual ~FileBase() = default;
+
         virtual bool write(const std::string &buffer) = 0;
 
         virtual std::string get_file_path() = 0;
@@ -29,6 +24,7 @@ namespace log_helper {
     class LocalFile : virtual public FileBase {
     protected:
         std::string file_path;
+
     public:
         explicit LocalFile(std::string file_path);
 
@@ -45,30 +41,28 @@ namespace log_helper {
         std::string server_ip;
         int32_t port;
         int32_t client_socket;
-        struct sockaddr_in server_address;
+        sockaddr_in server_address;
         bool is_ecc_enabled;
+
     public:
         UDPFile(std::string server_ip, int32_t port, bool is_ecc_enabled);
 
         bool write(const std::string &buffer) override;
 
         std::string get_file_path() override;
-
     };
 
     /**
      * To use both methods
      */
-    class LocalAndUDPFile : public LocalFile, public UDPFile {
+    class LocalAndUDPFile final : public LocalFile, public UDPFile {
     public:
-
         LocalAndUDPFile(const std::string &file_path, const std::string &server_ip, int32_t port,
                         bool is_ecc_enabled);
 
-        bool write(const std::string &buffer) final;
+        bool write(const std::string &buffer) override;
 
         std::string get_file_path() override;
     };
-
 } /*END NAMESPACE LOG_HELPER*/
 #endif //LOGHELPER_FILE_DESCRIPTOR_HPP

--- a/include/log_helper.h
+++ b/include/log_helper.h
@@ -76,17 +76,18 @@ int log_error_detail(const char *error_detail);
  */
 int log_info_detail(const char *info_detail);
 
-/**
- * Update with current timestamp the file where the software watchdog watches
- */
-void update_timestamp();
+// Deprecated 12/2024
+// /**
+//  * Update with current timestamp the file where the software watchdog watches
+//  */
+// void update_timestamp();
 
 /**
  * Stores the name of the log file generated in
  * log_file_name, and returns the pointer to the
  * same variable
  */
-char* get_log_file_name(char *log_file_name);
+char *get_log_file_name(char *log_file_name);
 
 //end C++ macro section
 #ifdef __cplusplus

--- a/include/log_helper.hpp
+++ b/include/log_helper.hpp
@@ -32,7 +32,7 @@ namespace log_helper {
 
     void disable_double_error_kill();
 
-    void update_timestamp();
+    // void update_timestamp(); deprecated 12/2024
 
     std::string get_log_file_name();
 } /*END NAMESPACE LOG_HELPER*/

--- a/src/file_writer.cpp
+++ b/src/file_writer.cpp
@@ -2,7 +2,12 @@
 // Created by fernando on 09/03/2022.
 //
 #include <vector>
+#include <fstream>
+#include <iostream>
+#include <arpa/inet.h>
+
 #include "file_writer.hpp"
+#include "common.hpp"
 
 namespace log_helper {
 #define ECC_ENABLED 0xE
@@ -40,7 +45,7 @@ namespace log_helper {
      * Networking file writing
      */
     UDPFile::UDPFile(std::string server_ip, const int32_t port, const bool is_ecc_enabled)
-            : server_ip(std::move(server_ip)), port(port), server_address({}), is_ecc_enabled(is_ecc_enabled) {
+        : server_ip(std::move(server_ip)), port(port), server_address({}), is_ecc_enabled(is_ecc_enabled) {
         //  Prepare our context and socket
         // Filling server information
         this->client_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -59,13 +64,14 @@ namespace log_helper {
         if (this->is_ecc_enabled) {
             ecc = ECC_ENABLED;
         }
-        std::string new_buffer = ecc + buffer;
+        const std::string new_buffer = ecc + buffer;
+
         if (sendto(
                 this->client_socket,
                 new_buffer.data(),
                 new_buffer.size(),
                 MSG_CONFIRM,
-                (const struct sockaddr *) &this->server_address,
+                reinterpret_cast<const sockaddr *>(&this->server_address),
                 sizeof(this->server_address)) == -1) {
             EXCEPTION_MESSAGE("[ERROR Unable to send the message " + buffer + "]");
             return false;
@@ -82,7 +88,7 @@ namespace log_helper {
      */
     LocalAndUDPFile::LocalAndUDPFile(const std::string &file_path, const std::string &server_ip, const int32_t port,
                                      const bool is_ecc_enabled)
-            : LocalFile(file_path), UDPFile(server_ip, port, is_ecc_enabled) {
+        : LocalFile(file_path), UDPFile(server_ip, port, is_ecc_enabled) {
         // Send the file path to have a reference on the server
         UDPFile::write("#LOGFILE " + this->file_path);
     }
@@ -94,5 +100,4 @@ namespace log_helper {
     std::string LocalAndUDPFile::get_file_path() {
         return "LOCAL:" + this->file_path + " " + UDPFile::get_file_path();
     }
-
 } /*END NAMESPACE LOG_HELPER*/

--- a/src/file_writer.cpp
+++ b/src/file_writer.cpp
@@ -54,7 +54,7 @@ namespace log_helper {
         }
         this->server_address.sin_family = AF_INET;
         this->server_address.sin_port = htons(this->port);
-        if (inet_pton(AF_INET, this->server_ip.c_str(), &(this->server_address.sin_addr.s_addr)) == -1) {
+        if (inet_pton(AF_INET, this->server_ip.c_str(), &this->server_address.sin_addr.s_addr) == -1) {
             EXCEPTION_MESSAGE("[ERROR Unable to  convert IPv4/IPv6 addresses from text to binary form]");
         }
     }

--- a/src/log_helper_c_wrapper.cpp
+++ b/src/log_helper_c_wrapper.cpp
@@ -5,6 +5,7 @@
 
 #include "log_helper.h"
 #include "log_helper.hpp"
+
 extern "C" {
 /**
 * C wrapper
@@ -58,23 +59,25 @@ int log_error_detail(const char *error_detail) {
 }
 
 int log_info_detail(const char *info_detail) {
-    if (info_detail == nullptr){
+    if (info_detail == nullptr) {
         return -1;
     }
     return log_helper::log_info_detail(info_detail);
 }
 
-void update_timestamp() {
-    log_helper::update_timestamp();
-}
+// Deprecated 12/2024
+// void update_timestamp() {
+//     log_helper::update_timestamp();
+// }
 
 char *get_log_file_name(char *log_file_name) {
     auto file_path = log_helper::get_log_file_name();
 
-    if (log_file_name != nullptr && strlen(log_file_name) >= file_path.size()){
+    if (log_file_name != nullptr && strlen(log_file_name) >= file_path.size() + 1){
         std::copy(file_path.begin(), file_path.end(), log_file_name);
+        // Null-terminate the string
+        log_file_name[file_path.size()] = '\0';
     }
     return log_file_name;
 }
-
 }


### PR DESCRIPTION
New version of libLogHelper:
- Removed the old setup support that included the update_timestamp functions and signal-sending
- The logging type is now set as an attribute of the config file
- Added a doc file with a description of the main functions.